### PR TITLE
Add optional auth guard.

### DIFF
--- a/src/api/common/guards/optionalAuth.guard.ts
+++ b/src/api/common/guards/optionalAuth.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+@Injectable()
+export class OptionalAuthGuard extends AuthGuard('jwt') {
+  getRequest(context: ExecutionContext) {
+    const ctx = GqlExecutionContext.create(context);
+    return ctx.getContext().req;
+  }
+
+  handleRequest(err, user, info) {
+    // You can throw an exception based on either "info" or "err" arguments
+    if (err || info) {
+      return null;
+    }
+    return user;
+  }
+}

--- a/src/api/projects/projects.resolver.ts
+++ b/src/api/projects/projects.resolver.ts
@@ -8,7 +8,10 @@ import { PopulatedProjectUser, ProjectUser } from './entities/project-user.entit
 import { Organization } from '../organizations/entities/organization.entity';
 import { UserEntity } from '../common/decorators';
 import { User } from '../users/entities/user.entity';
+import { UseGuards } from '@nestjs/common';
+import { OptionalAuthGuard } from '../common/guards/optionalAuth.guard';
 
+@UseGuards(OptionalAuthGuard)
 @Resolver(() => Project)
 export class ProjectsResolver {
   constructor(private readonly projectsService: ProjectsService) {}


### PR DESCRIPTION
This guard permits an endpoint to be accesible for everyone, but if a logged in user access it, the user will be available in the context. For that reason, we can show more info to legged in users, for example.